### PR TITLE
splitlines instead of split('\n')

### DIFF
--- a/genxword.py
+++ b/genxword.py
@@ -177,7 +177,7 @@ def crossword2tex(nrow, ncol, words):
 
 if __name__ == "__main__":
     ncol, nrow = 30, 30
-    wordlist = [[line.split(':')[0].upper(), line.split(':')[1]] for line in open('words.txt').read().split('\n')]
+    wordlist = [[line.split(':')[0].upper(), line.split(':')[1]] for line in open('words.txt').read().splitlines()]
     wordlist = wordlist[:]
     cw = Crossword(nrow, ncol, ' ', wordlist)
     print(cw.compute_crossword())


### PR DESCRIPTION
Most text editors insert an eol character at the end of a file.  Using a words.txt with an eol at the end produces this error:
Traceback (most recent call last):
  File "genxword.py", line 180, in <module>
    wordlist = [[line.split(':')[0].upper(), line.split(':')[1]] for line in open('words.txt').read().split('\n')]
IndexError: list index out of range

This little change fixes it.
I'm using vim on Debian jessie.
